### PR TITLE
1. 将残留的ZoteroPane修改为Zotero.getActiveZoteroPane()避免报错;2. 增加按照颜色导出笔记。

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -14,7 +14,7 @@ import { exportNoteByType, exportSingleNote, getAllAnnotations } from "./modules
 import { groupBy } from "./utils/groupBy";
 import { sortFixedTags10ValuesLength, sortValuesLength } from "./utils/sort";
 // import { TagElementProps } from "zotero-plugin-toolkit/dist/tools/ui";
-import { annotationToNoteTags, annotationToNoteType } from "./hooksMenuEvent";
+import { annotationToNoteTags, annotationToNoteType, annotationToNoteColor } from "./hooksMenuEvent";
 import { createZToolkit } from "./utils/ztoolkit";
 
 async function onStartup() {
@@ -128,13 +128,16 @@ function onShortcuts(type: string) {
   }
 }
 
-async function onMenuEvent(type: "annotationToNoteTags" | "annotationToNoteType", data: { [key: string]: any }) {
+async function onMenuEvent(type: "annotationToNoteTags" | "annotationToNoteType" | "annotationToNoteColor", data: { [key: string]: any }) {
   switch (type) {
     case "annotationToNoteTags":
       annotationToNoteTags(data.window, data.type);
       break;
     case "annotationToNoteType":
       annotationToNoteType(data.window, data.type);
+      break;
+    case "annotationToNoteColor":
+      annotationToNoteColor(data.window, data.type);
       break;
     default:
       return;

--- a/src/hooksMenuEvent.ts
+++ b/src/hooksMenuEvent.ts
@@ -1,6 +1,6 @@
 import { TagElementProps } from "zotero-plugin-toolkit/dist/tools/ui";
 import { config } from "../package.json";
-import { getAllAnnotations, exportNoteByType, exportSingleNote } from "./modules/AnnotationsToNote";
+import { getAllAnnotations, exportNoteByType, exportSingleNote, exportNoteByColor } from "./modules/AnnotationsToNote";
 import { getSelectedItems } from "./modules/menu";
 import { groupBy } from "./utils/groupBy";
 import { sortValuesLength, sortFixedTags10ValuesLength } from "./utils/sort";
@@ -62,6 +62,70 @@ export async function annotationToNoteType(win: Window, collectionOrItem: "colle
               listener: (event: any) => {
                 stopPropagation(event);
                 exportNoteByType(tag.key as _ZoteroTypes.Annotations.AnnotationType, collectionOrItem);
+              },
+            },
+          ],
+        };
+      }),
+    };
+  }
+  ztoolkit.UI.appendElement(elemProp, popup);
+}
+
+export async function annotationToNoteColor(win: Window, collectionOrItem: "collection" | "item" = "collection") {
+  //用于弹出菜单
+  const doc = win.document;
+  const popup = doc.querySelector(`#${config.addonRef}-create-note-color-popup-${collectionOrItem}`) as XUL.MenuPopup;
+  // Remove all children in popup
+  while (popup?.firstChild) {
+    popup.removeChild(popup.firstChild);
+  }
+  // const id = getParentAttr(popup, "id");
+  // const isc = id?.includes("collection");
+  // ztoolkit.log("id", id);
+
+  const ans = getAllAnnotations(await getSelectedItems(collectionOrItem)); //.flatMap((a) => a.tags.map((t2) => Object.assign({}, a, { tag: t2 })));
+  const tags = groupBy(ans, (an) => an.color)
+    .sort(sortValuesLength)
+    .slice(0, 20);
+  const maxLen = Math.max(...tags.map((a) => a.values.length));
+
+  // Add new children
+  let elemProp: TagElementProps;
+  // const tags =memFixedTags()
+  if (tags.length === 0) {
+    elemProp = {
+      tag: "menuitem",
+      properties: {
+        label: "没有标签",
+      },
+      attributes: {
+        disabled: true,
+      },
+    };
+  } else {
+    elemProp = {
+      tag: "fragment",
+      children: tags.map((tag) => {
+        const color = tag.key;
+        //取对数可以保留差异比较大的值
+        const pre = (100 - (Math.log(tag.values.length) / Math.log(maxLen)) * 100).toFixed();
+        return {
+          tag: "menuitem",
+          icon: iconBaseUrl + "favicon.png",
+          styles: {
+            background: `linear-gradient(to left, ${color},  #fff ${pre}%, ${color} ${pre}%)`,
+          },
+          properties: {
+            label: `${tag.key}[${tag.values.length}]`,
+          },
+          // children:[{tag:"div",styles:{height:"2px",background:memFixedColor(tag.key),width:`${tag.values.length/maxLen*100}%`}}],
+          listeners: [
+            {
+              type: "command",
+              listener: (event: any) => {
+                stopPropagation(event);
+                exportNoteByColor(tag.key as string, collectionOrItem);
               },
             },
           ],

--- a/src/modules/menu.tsx
+++ b/src/modules/menu.tsx
@@ -239,6 +239,16 @@ function buildMenu(collectionOrItem: "collection" | "item") {
         tag: "menuseparator",
       },
       {
+        tag: "menu",
+        label: "选择单个Color导出",
+        icon: iconBaseUrl + "favicon.png",
+        popupId: `${config.addonRef}-create-note-color-popup-${collectionOrItem}`,
+        onpopupshowing: `Zotero.${config.addonInstance}.hooks.onMenuEvent("annotationToNoteColor", { window,type:"${collectionOrItem}" })`,
+      },
+      {
+        tag: "menuseparator",
+      },
+      {
         tag: "menuitem",
         label: "导出量表格式Note(测试中)",
         icon: iconBaseUrl + "favicon.png",
@@ -727,7 +737,7 @@ export async function getSelectedItems(isCollectionOrItem: boolean | "collection
       items = itemsAll.filter((f) => itemTypes.includes(f.itemType));
     }
   } else {
-    items = ZoteroPane.getSelectedItems();
+    items = Zotero.getActiveZoteroPane().getSelectedItems();
   }
   return items;
 }


### PR DESCRIPTION
- 发现无法在新版Zotero运行，查看报错发现是ZoteroPane的问题，将残留的ZoteroPane修改为Zotero.getActiveZoteroPane()避免报错。
- 根据自己的需求，增加按照颜色导出笔记，不过略显粗糙。