### PR TITLE
Fix sortBy descending comparison bug

### DIFF
--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -94,7 +94,7 @@ export function sortBy<T>(keyFunc: (a: T) => string, asc: boolean = true) {
     const bb = keyFunc(b);
     if (aa == bb) return 0;
     if (asc) return aa < bb ? -1 : 1;
-    return aa < aa ? -1 : 1;
+    return aa < bb ? 1 : -1;
   };
 }
 /**


### PR DESCRIPTION
## Summary
- correct the descending order logic in `sortBy` utility

## Testing
- `npm run lint:check` *(fails: code style issues)*
- `npm run build` *(fails: numerous TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848003b3008832da78ad20e87eafad3